### PR TITLE
Added Librarian authorization to create book

### DIFF
--- a/JeffersonCountyLibrary/Controllers/BooksController.cs
+++ b/JeffersonCountyLibrary/Controllers/BooksController.cs
@@ -24,6 +24,7 @@ namespace JeffersonCountyLibrary.Controllers
         }
 
         // GET: Books/Create
+        [Authorize(Roles = "Librarian")]
         public IActionResult Create()
         {
             ViewData["BranchId"] = new SelectList(_context.Branches, "Id", "Id");
@@ -35,6 +36,7 @@ namespace JeffersonCountyLibrary.Controllers
         // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = "Librarian")]
         public IActionResult Create(Book book)
         {
             book.Branch = _context.Branches.Find(book.BranchId);
@@ -45,6 +47,7 @@ namespace JeffersonCountyLibrary.Controllers
         }
 
         [HttpGet]
+        [Authorize]
         public IActionResult CheckOut(int? id)
         {
             var book = _context.Books.Find(id);

--- a/JeffersonCountyLibrary/Program.cs
+++ b/JeffersonCountyLibrary/Program.cs
@@ -37,4 +37,6 @@ app.MapControllerRoute(
     name: "default",
     pattern: "{controller=Home}/{action=Index}/{id?}");
 
+app.MapRazorPages();
+
 app.Run();

--- a/JeffersonCountyLibrary/Views/Shared/_Layout.cshtml
+++ b/JeffersonCountyLibrary/Views/Shared/_Layout.cshtml
@@ -25,6 +25,12 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Branches" asp-action="Index">Branches</a>
                         </li>
+                        @if (User.IsInRole("Librarian"))
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link text-dark" asp-area="" asp-controller="Books" asp-action="Create">Add Book</a>
+                            </li>
+                        }
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
                         </li>


### PR DESCRIPTION
1. Upon initially running this application, I noticed that Identity was set up but we were unable to register users. I saw that we were missing the line app.MapRazorPages(); in program.cs. This configures the routing for the Identity Razor pages and will allow us to access the Razor page to register new users.
2. I added the [Authorize] attribute to the CheckOut() action in the Books controller so that only a logged-in user can check out a book.
3. To improve the functionality of the create book action, I first created the role of "Librarian" in the database. Then, I added logic to the layout so that the nav bar would only display the "Add Book" button if the logged-in user had the role of Librarian. Additionally, to ensure only Librarians can add a book, I added a [Authorize(Roles = "Librarian")] attribute to both the Create() action and Post Create() action.